### PR TITLE
fix: handling query well

### DIFF
--- a/packages/cache-dependency/package-lock.json
+++ b/packages/cache-dependency/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@anchan828/nest-cache-dependency",
-			"version": "0.10.5",
+			"version": "0.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"cache-manager": "3.6.0",

--- a/packages/cache-dependency/src/cache-dependency.interceptor.ts
+++ b/packages/cache-dependency/src/cache-dependency.interceptor.ts
@@ -22,16 +22,16 @@ export class CacheDependencyInterceptor implements NestInterceptor {
 
   public async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
     const request = context.switchToHttp().getRequest();
-    
+
     const routeParams = request.params ?? {};
     const query = request.query ?? {};
-    
+
     let wsParams = {};
     if (request.handshake) {
       const wsData = context.switchToWs().getData();
       if (wsData instanceof Object && !Array.isArray(wsData) && !Buffer.isBuffer(wsData)) wsParams = wsData;
     }
-    
+
     const params = { ...routeParams, ...wsParams, ...query };
     let cacheKey = this.reflector.get(CACHE_KEY_METADATA, context.getHandler()) as string;
 
@@ -55,7 +55,7 @@ export class CacheDependencyInterceptor implements NestInterceptor {
           if (cacheKey) {
             graph.addNode(cacheKey, response);
           }
-          func(cacheKey, response, graph);
+          func(cacheKey, response, graph, params);
           await this.service.createCacheDependencies(graph);
         }
         if (Array.isArray(clearCacheKeys)) {

--- a/packages/cache-dependency/src/cache-dependency.interface.ts
+++ b/packages/cache-dependency/src/cache-dependency.interface.ts
@@ -5,7 +5,12 @@ import { RedisOptions } from "ioredis";
  * Wraps dependency-graph
  */
 export type CacheDependencyGraph = DepGraph<any>;
-export type CacheDependencyFunction<T> = (cacheKey: string, o: T, graph: CacheDependencyGraph) => void;
+export type CacheDependencyFunction<T, RawParams = any> = (
+  cacheKey: string,
+  o: T,
+  graph: CacheDependencyGraph,
+  rawParams?: RawParams,
+) => void;
 export type CreateCacheDependencyFunction = (graph: CacheDependencyGraph) => void | Promise<void>;
 
 export interface CacheDependencyModuleOptions extends CacheModuleOptions {

--- a/packages/cache-manager-ioredis/package-lock.json
+++ b/packages/cache-manager-ioredis/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@anchan828/nest-cache-manager-ioredis",
-			"version": "0.10.5",
+			"version": "0.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"cache-manager": "3.6.0",


### PR DESCRIPTION
Add rawParams parameter to customize cache key

```ts
  @Get("users/:userId/items")
  @CacheKey("users/:userId/items?name=:name")
  @CacheDependency<Item[]>(
    (cacheKey: string, items: Item[], graph: CacheDependencyGraph, rawParams: { userId: string }) => {
      const key = `users/${rawParams.userId}/items`;

      for (const item of items) {
        // e.g. users/1/items/2
        graph.addNode(`${key}/${item.id}`, item);

        // When an item is updated, it should be deleted both when filtered by name and when not.
        graph.addNode(key);
        graph.addDependency(`${key}/${item.id}`, key);
        graph.addDependency(`${key}/${item.id}`, cacheKey);
      }
    },
  )
```